### PR TITLE
Add UI console mode to MGMT firmware

### DIFF
--- a/firmware/mgmt/inc/state.h
+++ b/firmware/mgmt/inc/state.h
@@ -6,6 +6,7 @@ enum State
     Error,
     Running,
     UI_Upload,
+    UI_Console,
     Net_Upload,
     Normal,
     Debug,

--- a/firmware/mgmt/inc/uart_stream.h
+++ b/firmware/mgmt/inc/uart_stream.h
@@ -46,6 +46,7 @@ static const uint8_t ui_upload_cmd[] = "ui_upload";
 static const uint8_t net_upload_cmd[] = "net_upload";
 static const uint8_t debug_cmd[] = "debug";
 static const uint8_t ui_debug_cmd[] = "ui_debug";
+static const uint8_t ui_console_cmd[] = "ui_console";
 static const uint8_t net_debug_cmd[] = "net_debug";
 static const uint8_t reset_cmd[] = "reset";
 static const uint8_t reset_net[] = "reset_net";

--- a/firmware/mgmt/src/app_mgmt.c
+++ b/firmware/mgmt/src/app_mgmt.c
@@ -270,6 +270,13 @@ int app_main(void)
             LEDA(LOW, HIGH, LOW);
             break;
         }
+        case UI_Console:
+        {
+            NormalInit();
+            SetStreamModes(Passthrough, Passthrough, Ignore);
+            LEDA(HIGH, HIGH, HIGH);
+            break;
+        }
         case Net_Debug:
         {
             NormalInit();

--- a/firmware/mgmt/src/uart_stream.c
+++ b/firmware/mgmt/src/uart_stream.c
@@ -165,6 +165,10 @@ void HandleCommands(uart_stream_t* stream, enum State* state)
         {
             *state = UI_Debug;
         }
+        else if (strcmp((const char*)cmd_buff, (const char*)ui_console_cmd) == 0)
+        {
+            *state = UI_Console;
+        }
         else if (strcmp((const char*)cmd_buff, (const char*)net_debug_cmd) == 0)
         {
             *state = Net_Debug;


### PR DESCRIPTION
This PR adds a mode to the MGMT firmware that does bidirectional forwarding between the USB UART interface and the UI chip.  I have called it "console" mode because it basically gives you a full serial port to the UI chip.