### PR TITLE
Add Rust format checks for Link crates

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -19,7 +19,7 @@ jobs:
         uses: jidicula/clang-format-action@v4.13.0
         with:
           clang-format-version: '18'
-          exclude-regex: '(lib|Drivers|Core|net/include/sys|net/include/netinet|cmox)'
+          exclude-regex: '(lib|Drivers|Core|net/include/sys|net/include/netinet|cmox|sframe|link/)'
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary

Updates CI to include Rust format checking for the Link submodule crates:

- **format.yml**: Split into `format-cpp` and `format-rust` jobs
  - `format-cpp`: Existing clang-format check for C/C++ code
  - `format-rust`: New job checking `cargo fmt` for link, mgmt, and ctl crates

- **build-ci.yml**: Remove `test-link` job
  - Link repo (link-rs/link) has its own CI that runs tests
  - Avoids duplicate test runs

## Test plan

- [x] Verify format-cpp job still works
- [x] Verify format-rust job checks all three crates
- [x] Verify build jobs still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)