### PR TITLE
Add source file dependencies for MGMT and CTL Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,17 @@ UI_BIN := firmware/ui/build/ui.bin
 NET_ELF := firmware/net/build/net.elf
 NET_PARTITION := firmware/net/build/partition_table/partition-table.bin
 
+# Source file dependencies for Rust crates
+CTL_SRCS := $(shell find link/ctl/src -name '*.rs') link/ctl/Cargo.toml
+MGMT_SRCS := $(shell find link/mgmt/src -name '*.rs') link/mgmt/Cargo.toml
+LINK_SRCS := $(shell find link/link/src -name '*.rs') link/link/Cargo.toml
+
 all: $(CTL_BIN) $(MGMT_BIN) $(UI_BIN) $(NET_ELF)
 
-$(CTL_BIN):
+$(CTL_BIN): $(CTL_SRCS) $(LINK_SRCS)
 	cd link/ctl && cargo build --release
 
-$(MGMT_BIN):
+$(MGMT_BIN): $(MGMT_SRCS) $(LINK_SRCS)
 	cd link/mgmt && cargo objcopy --release -- -O binary target/thumbv6m-none-eabi/release/mgmt.bin
 
 $(UI_BIN): FORCE


### PR DESCRIPTION
## Summary

Updates the root Makefile so that MGMT and CTL targets depend on their source files:

- `$(CTL_BIN)` depends on `link/ctl/src/*.rs` and `link/ctl/Cargo.toml`
- `$(MGMT_BIN)` depends on `link/mgmt/src/*.rs` and `link/mgmt/Cargo.toml`
- Both also depend on `link/link/src/*.rs` (the shared library)

This allows Make to skip rebuilding when sources haven't changed.

## Test plan

- [ ] `make` only rebuilds CTL/MGMT when their sources change
- [ ] Modifying a source file triggers rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)